### PR TITLE
Update submodules with public clone URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodule/conveyor_bins"]
 	path = submodule/conveyor_bins
-	url = git@github.com:makerbot/conveyor_bins.git
+	url = https://github.com/makerbot/conveyor_bins.git


### PR DESCRIPTION
Only contributors have access to the `git@` URL for cloning. This just adjusts it to an HTTP path so anyone can use it.
