### PR TITLE
Added variable inits to copy_avrdude.py to fix windows error

### DIFF
--- a/copy_avrdude.py
+++ b/copy_avrdude.py
@@ -4,6 +4,10 @@ import shutil
 import optparse
 import sys
 
+avrdude_name = ""
+platform_folder = ""
+files = []
+
 parser = optparse.OptionParser()
 parser.add_option('-p', '--platform', dest='platform',
                   help='The platform you are you', default=None)


### PR DESCRIPTION
While attempting to use the copy_avrdude.py script on my Windows 7 x64 environment, using Cygwin and Python 2.7.3, I ran into the following error:

``` sh
Traceback (most recent call last):
  File "copy_avrdude.py", line 49, in <module>
    if not os.path.isfile(os.path.join(path_to_firmware, avrdude_name)):
NameError: name 'avrdude_name' is not defined
```

And later this error:

``` sh
Copying avrdude files into /home/okeefm/s3g/makerbot_driver/Firmware
Traceback (most recent call last):
  File "copy_avrdude.py", line 51, in <module>
    for file in files:
NameError: name 'files' is not defined

```

These errors were solved by defining `avrdude_name`, `platform_folder` (for completeness) and `files` before parsing the argument values and checking the platform type.
